### PR TITLE
Fix completion information being clobbered for dot notation access and same-file variables.

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,9 +124,8 @@ monaco.languages.typescript.getTypeScriptWorker()
 								range: new monaco.Range(1, 1, 1, 1),
 								text: `import { ${completion.insertText ?? completion.name} } from '${completion.data?.moduleSpecifier}';\n`,
 							}];
+							acc.push(suggestion);
 						}
-		
-						acc.push(suggestion);
 		
 						return acc;
 					},

--- a/myWorker.js
+++ b/myWorker.js
@@ -5,12 +5,6 @@
  */
 const customTSWorkerFactory = (TypeScriptWorker) => {
     return class MyTypeScriptWorker extends TypeScriptWorker {
-
-        // Make the default method return nothing to avoid double completions
-        getCompletionsAtPosition() {
-            return undefined;
-        }
-
         /**
          * Add our own method to get completions
          * @type {import('./types').MyTypeScriptWorker['getMyCompletionsAtPosition']}


### PR DESCRIPTION
Currently with this repo's solution, we have the following problems:

No dot operator suggestions:
![image](https://github.com/user-attachments/assets/dbc59273-f212-4fde-a06c-5d92d44c46a9)

Clobbered type information for variables in the same file:
![image](https://github.com/user-attachments/assets/fd9d9c79-4efa-4d2c-b529-af99b0147982)


## After this patch, these issues are fixed:
Dot operator suggestions:
![image](https://github.com/user-attachments/assets/338986ec-bf7f-442d-bb6a-079701de6466)

Local variable type information:
![image](https://github.com/user-attachments/assets/e6e5f2d8-05f5-4cb5-aead-204c580a185f)

Additionally, we have no regressions:
- Autocompleting / importing from other files automatically still works perfectly
- Duplicate autocomplete entries never appear
